### PR TITLE
타일에만 충돌 레이어 작동하도록 수정

### DIFF
--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -255,6 +255,36 @@ export class Player {
     }
   }
 
+  public setStat(statName: keyof PlayerStats, value: number): void {
+    if (typeof this.stats[statName] === 'number') {
+      (this.stats as any)[statName] = value;
+
+      // 항목별 클램핑/연쇄 보정
+      if (statName === 'health') {
+        this.stats.health = Math.max(0, Math.min(this.stats.health, this.stats.maxHealth));
+      }
+      if (statName === 'maxHealth') {
+        // 최대 체력 변경 시 현재 체력 클램핑
+        this.stats.health = Math.max(0, Math.min(this.stats.health, this.stats.maxHealth));
+      }
+      if (statName === 'hearts_p1') {
+        this.stats.hearts_p1 = Math.max(0, Math.min(this.stats.hearts_p1, this.stats.maxHearts_p1 ?? this.stats.hearts_p1));
+      }
+      if (statName === 'hearts_p2') {
+        this.stats.hearts_p2 = Math.max(0, Math.min(this.stats.hearts_p2, this.stats.maxHearts_p2 ?? this.stats.hearts_p2));
+      }
+      if (statName === 'maxHearts_p1' && this.stats.maxHearts_p1 < this.stats.hearts_p1) {
+        this.stats.hearts_p1 = this.stats.maxHearts_p1;
+      }
+      if (statName === 'maxHearts_p2' && this.stats.maxHearts_p2 < this.stats.hearts_p2) {
+        this.stats.hearts_p2 = this.stats.maxHearts_p2;
+      }
+
+      SaveManager.updatePlayerStats({ [statName]: this.stats[statName] } as Partial<PlayerStats>);
+      console.log(`${statName} 설정:`, this.stats[statName]);
+    }
+  }
+
   public getStats(): PlayerStats {
     return { ...this.stats };
   }

--- a/src/systems/MapManager.ts
+++ b/src/systems/MapManager.ts
@@ -98,6 +98,7 @@ export class MapManager {
     this.renderer.render(data, layerDepths, tilesTextureKey);
 
     // 충돌
+    this.collision.setTilesTextureKey(tilesTextureKey);
     if (tilesMeta) this.collision.setTilesMeta(tilesMeta);
     this.collision.build(data);
 


### PR DESCRIPTION
Ensures collision layers only apply to visible (non-transparent) tile areas.

Previously, collision bodies were created for the entire tile area, including transparent pixels. This change modifies the collision builder to inspect tile texture frames, determine the bounding box of opaque pixels, and create colliders only within these visible regions. Fully transparent tiles will no longer generate colliders.

---
<a href="https://cursor.com/background-agent?bcId=bc-b54449f8-5ffe-4b68-9ed2-6ac2ee76050b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b54449f8-5ffe-4b68-9ed2-6ac2ee76050b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

